### PR TITLE
詳細表示機能の追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :check_login, only: [:new, :create]
+  before_action :get_item, only: :show
 
   def index
     @items = Item.all
@@ -19,7 +20,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private
@@ -30,5 +30,9 @@ class ItemsController < ApplicationController
 
   def check_login
     redirect_to action: :index unless user_signed_in?
+  end
+
+  def get_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :description, :image, :price, :type_id, :burden_id, :prefectures_id, :days_id, :condition_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :description, :image, :price, :type_id, :burden_id, :prefecture_id, :day_id, :condition_id).merge(user_id: current_user.id)
   end
 
   def check_login

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,8 +14,8 @@ class Item < ApplicationRecord
     validates :condition_id
     validates :type_id
     validates :burden_id
-    validates :prefectures_id
-    validates :days_id
+    validates :prefecture_id
+    validates :day_id
     validates :price, numericality: { greater_than: 299, less_than: 10_000_000 }
   end
 end

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -2,14 +2,7 @@
         <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '100x100'), class: "item-img" %>
-
-          <%# 商品が売れていればsold outの表示 %>
-          <% if item.price > 50000 %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-          <% end %>
-          <%# //商品が売れていればsold outの表示 %>
+            <%= render partial: "sold_out", locals: { item: item } %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/_items.html.erb
+++ b/app/views/items/_items.html.erb
@@ -1,5 +1,5 @@
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '100x100'), class: "item-img" %>
 

--- a/app/views/items/_sold_out.html.erb
+++ b/app/views/items/_sold_out.html.erb
@@ -1,5 +1,5 @@
           <%# 商品が売れていればsold outの表示 %>
-          <% if item.price > 50000 %>
+          <% if item != nil %>
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>

--- a/app/views/items/_sold_out.html.erb
+++ b/app/views/items/_sold_out.html.erb
@@ -1,0 +1,7 @@
+          <%# 商品が売れていればsold outの表示 %>
+          <% if item.price > 50000 %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+          <% end %>
+          <%# //商品が売れていればsold outの表示 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -76,12 +76,12 @@
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefectures_id, Prefecture.all, :id, :name, {prompt: "--"}, {class:"select-box"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {prompt: "--"}, {class:"select-box"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days_id, Day.all, :id, :name, {prompt: "--"}, {class:"select-box"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {prompt: "--"}, {class:"select-box"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,10 +16,14 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        <% if @item.burden == 1 %>
+          (税込) 送料込み
+        <% else %>
+          (税込) 送料　購入者負担
+        <% end %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
     <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if if user_signed_in? && current_user.id != @item.user_id %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -50,23 +50,23 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.type %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.burden %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.day %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,9 +29,11 @@
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -50,23 +50,23 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.type %></td>
+          <td class="detail-value"><%= @item.type[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.condition %></td>
+          <td class="detail-value"><%= @item.condition[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.burden %></td>
+          <td class="detail-value"><%= @item.burden[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.day %></td>
+          <td class="detail-value"><%= @item.prefecture[:name] %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.days %></td>
+          <td class="detail-value"><%= @item.day[:name] %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,7 +40,7 @@
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,7 +19,7 @@
         ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <% if @item.burden == 1 %>
+        <% if @item.burden_id == 1 %>
           (税込) 送料込み
         <% else %>
           (税込) 送料　購入者負担

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,8 +27,6 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
@@ -36,7 +34,9 @@
     <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,10 +9,8 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+      <%= render partial: "sold_out", locals: { item: @item } %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items,only: [:index,:new,:create]
+  resources :items,only: [:index,:new,:create,:show]
 end

--- a/db/migrate/20200720031807_create_items.rb
+++ b/db/migrate/20200720031807_create_items.rb
@@ -9,8 +9,8 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :condition_id
       t.integer :type_id
       t.integer :burden_id
-      t.integer :prefectures_id
-      t.integer :days_id
+      t.integer :prefecture_id
+      t.integer :day_id
       t.timestamps
     end
   end

--- a/db/migrate/20200720031807_create_items.rb
+++ b/db/migrate/20200720031807_create_items.rb
@@ -9,8 +9,8 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :condition_id
       t.integer :type_id
       t.integer :burden_id
-      t.integer :prefecture_id
-      t.integer :day_id
+      t.integer :prefectures_id
+      t.integer :days_id
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 2020_07_22_051550) do
     t.integer "condition_id"
     t.integer "type_id"
     t.integer "burden_id"
-    t.integer "prefectures_id"
-    t.integer "days_id"
+    t.integer "prefecture_id"
+    t.integer "day_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     condition_id          { '1' }
     type_id               { '1' }
     burden_id             { '1' }
-    prefectures_id        { '1' }
-    days_id               { '1' }
+    prefecture_id        { '1' }
+    day_id               { '1' }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -71,15 +71,15 @@ describe Item do
     end
 
     it '発送元の地域が無いと登録できない事を確認' do
-      @item.prefectures_id = ''
+      @item.prefecture_id = ''
       @item.valid?
-      expect(@item.errors[:prefectures_id]).to include("can't be blank")
+      expect(@item.errors[:prefecture_id]).to include("can't be blank")
     end
 
     it '発送までの日数が無いと登録できない事を確認' do
-      @item.days_id = ''
+      @item.day_id = ''
       @item.valid?
-      expect(@item.errors[:days_id]).to include("can't be blank")
+      expect(@item.errors[:day_id]).to include("can't be blank")
     end
   end
 end


### PR DESCRIPTION
### what
showアクションで詳細を表示
active_hashに格納されたデータと紐付けし、カテゴリ名や、発送元の地域などを表示
deviseのメソッドを利用し、ログインしているかどうか、出品者と同一人物がどうかを元に編集削除リンクや商品購入リンクの表示の可否を決定
※商品購入機能はまだ未実装のため、sold outの表記は別の条件によって表示の可否を決定しています。

### why
このアプリの根幹部分であるため必須

### 以下画像やgif
出品者と同一人物がログイン時の画像
https://gyazo.com/ddf49c5e4bd04f11dabe7112257caca6
出品者と別人物がログイン時の画像
https://gyazo.com/111ff9330a69d18bfb4b81e14594218e
未ログインにて詳細の閲覧のgif
https://gyazo.com/31531395dd76ce242dc69d0f4cabd357

